### PR TITLE
recipe change use tin instead of clay for princess material

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -454,9 +454,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "princess:princess_pink_material",
 	recipe = {
-		{"default:clay_lump", "default:clay_lump", "default:clay_lump"},
-		{"default:clay_lump", "dye:pink", "default:clay_lump"},
-		{"default:clay_lump", "default:clay_lump", "default:clay_lump"}
+		{"default:tin_lump", "default:tin_lump", "default:tin_lump"},
+		{"default:tin_lump", "dye:pink", "default:tin_lump"},
+		{"default:tin_lump", "default:tin_lump", "default:tin_lump"},
 	}
 })
 
@@ -482,9 +482,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "princess:princess_white_material",
 	recipe = {
-		{"default:clay_lump", "default:clay_lump", "default:clay_lump"},
-		{"default:clay_lump", "dye:white", "default:clay_lump"},
-		{"default:clay_lump", "default:clay_lump", "default:clay_lump"}
+		{"default:tin_lump", "default:tin_lump", "default:tin_lump"},
+		{"default:tin_lump", "dye:white", "default:tin_lump"},
+		{"default:tin_lump", "default:tin_lump", "default:tin_lump"},
 	}
 })
 


### PR DESCRIPTION
fix #1

Tin is mostly unused ore introduced in MTG-0.4.16, so it should be easy to collect them. Ant it is more stainless
